### PR TITLE
Make shamefully-hoist a default option for PNPM

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true


### PR DESCRIPTION
Hi Michael,

I noticed with the stable release of nuxi / nuxt3, when bootstrapping a new project it adds a `.npmrc` file with the shamefully-hoist flag set to true. I think this should also be added to the repository to avoid errors like:

`at vue (imported from ./node_modules/.pnpm/nuxt@3.0.0/node_modules/nuxt/dist/app/entry.mjs)`

when you install the project without the --shamefully-hoist flag set via pnpm.